### PR TITLE
Hotfix 0

### DIFF
--- a/commitments-oapi.yml
+++ b/commitments-oapi.yml
@@ -27,9 +27,9 @@ x-constants:
   MAX_CONSTRAINTS_PER_SLOT: 32
 
 paths:
-  /commitments/v0/gateway/commitment:
+  /commitments/v0/gateway/commitmentRequest:
     post:
-      operationId: "postCommitment"
+      operationId: "postCommitmentRequest"
       tags:
         - Commitments API
       summary: "Request a new SignedCommitment"
@@ -58,9 +58,9 @@ paths:
           description: "Bad Request - Invalid commitment request"
         "500":
           description: "Internal Server Error"
-  /commitments/v0/gateway/commitment/{request_hash}:
+  /commitments/v0/gateway/commitmentResult/{request_hash}:
     get:
-      operationId: "getCommitment"
+      operationId: "getCommitmentResult"
       tags:
         - Commitments API
       summary: "Request an old SignedCommitment"

--- a/commitments-oapi.yml
+++ b/commitments-oapi.yml
@@ -71,8 +71,8 @@ paths:
           in: path
           required: true
           schema:
-            type: bytes32
-            format: string
+            type: string
+            format: bytes32
           description: Hash of the CommitmentRequest to retrieve
           example: "0x1234567890123456789012345678901234567890000000000000000000000000"
       responses:

--- a/commitments-oapi.yml
+++ b/commitments-oapi.yml
@@ -71,8 +71,8 @@ paths:
           in: path
           required: true
           schema:
-            type: integer
-            format: uint64
+            type: bytes32
+            format: string
           description: Hash of the CommitmentRequest to retrieve
           example: "0x1234567890123456789012345678901234567890000000000000000000000000"
       responses:
@@ -180,6 +180,7 @@ components:
           example: ""
         request_hash:
           type: string
+          format: bytes32
           description: Hash of the CommitmentRequest this Commitment is for
           example: "0x1234567890123456789012345678901234567890000000000000000000000000"
         slasher:

--- a/specs/commitments-api.md
+++ b/specs/commitments-api.md
@@ -61,7 +61,7 @@ class Commitment(Container):
     # Opaque payload bytes of the commitment
     payload: Bytes
     # Hash of the CommitmentRequest this Commitment is for
-    request_hash: uint64
+    request_hash: Bytes32
     # Slasher contract for resolving commitment disputes
     slasher: Address
 ```

--- a/specs/commitments-api.md
+++ b/specs/commitments-api.md
@@ -34,8 +34,8 @@ The [Constraints Specs](https://github.com/eth-fabric/constraints-specs) and [AP
 
 | **Namespace** | **Method** | **Endpoint** | **Description** |
 | --- | --- | --- | --- |
-| `commitments`   | `POST` | [/commitments/v0/gateway/commitment](commitments-api.md#postcommitmentrequest)        | Request a new `SignedCommitment`  |
-| `commitments`   | `GET` | [/commitments/v0/gateway/commitment](commitments-api.md#getsignedcommitment)        | Request an old `SignedCommitment` |
+| `commitments`   | `POST` | [/commitments/v0/gateway/commitmentRequest](commitments-api.md#postcommitmentrequest)        | Request a new `SignedCommitment`  |
+| `commitments`   | `GET` | [/commitments/v0/gateway/commitmentResult](commitments-api.md#getcommitmentresult)        | Request an old `SignedCommitment` |
 | `commitments`   | `GET` | [/commitments/v0/gateway/slots](commitments-api.md#getslots)        | Get Gateway information for upcoming slots |
 | `commitments`   | `POST` | [/commitments/v0/gateway/fee](commitments-api.md#getfeeinfo)        | Get commitment fee information |
 
@@ -118,7 +118,7 @@ class FeeInfo(Container):
 
 ### **postCommitmentRequest**
 
-- **Method:** `POST /commitments/v0/gateway/commitment`
+- **Method:** `POST /commitments/v0/gateway/commitmentRequest`
 - **Response:** `SignedCommitment`
 - **Headers:**
     - `Content-Type: application/json`
@@ -134,9 +134,9 @@ class FeeInfo(Container):
 
 ---
 
-### **getSignedCommitment**
+### **getCommitmentResult**
 
-- **Method:** `GET /commitments/v0/gateway/commitment/{request_hash}`
+- **Method:** `GET /commitments/v0/gateway/commitmentResult/{request_hash}`
 - **Response:** `SignedCommitment`
 - **Body:** `None`
 


### PR DESCRIPTION
Quick fixes from implementation feedback:

- `request_hash` fixed to be a `bytes32`
- post and get `/commitment` renamed to `/commitmentRequest` and `commitmentResult`