### PR TITLE
Testnet Changes

### DIFF
--- a/commitments-jsonrpc.yml
+++ b/commitments-jsonrpc.yml
@@ -375,12 +375,24 @@ components:
                 - payload
                 - request_hash
                 - slasher
+            nonce:
+              type: integer
+              format: uint64
+              description: The nonce used when signing
+              example: 123456
+            signing_id:
+              type: string
+              format: bytes32
+              description: The signing ID used when signing
+              example: "0x1111111111111111111111111111111111111111111111111111111111111111"
             signature:
               type: string
               description: The ECDSA signature of the commitment message
               example: "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1b"
           required:
             - commitment
+            - nonce
+            - signing_id
             - signature
         id:
           oneOf:

--- a/specs/commitments-api.md
+++ b/specs/commitments-api.md
@@ -72,6 +72,10 @@ class Commitment(Container):
 class SignedCommitment(Container):
     # The commitment message that was signed
     commitment: Commitment
+    # The nonce used when signing
+    nonce: uint64
+    # The signing ID used when signing
+    signing_id: Bytes32
     # The signature of the commitment message
     signature: ECDSASignature
 ```
@@ -154,6 +158,8 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"commitmentRequest","params":[{"c
       "request_hash": "0x1234567890123456789012345678901234567890000000000000000000000000",
       "slasher": "0x1234567890123456789012345678901234567890"
     },
+    "nonce": 123456,
+    "signing_id": "0x1111111111111111111111111111111111111111111111111111111111111111",
     "signature": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1b"
   }
 }
@@ -192,6 +198,8 @@ curl -X POST --data '{"jsonrpc":"2.0","method":"commitmentResult","params":[{"re
       "request_hash": "0x1234567890123456789012345678901234567890000000000000000000000000",
       "slasher": "0x1234567890123456789012345678901234567890"
     },
+    "nonce": 123456,
+    "signing_id": "0x1111111111111111111111111111111111111111111111111111111111111111",
     "signature": "0x1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef1b"
   }
 }


### PR DESCRIPTION
- Add nonce and signing_id to SignedCommitment schema so that the signature can be verified. Assumes that the `SignedCommitment.signature` follows the [Commit-Boost Signing Spec](https://commit-boost.github.io/commit-boost-client/api/).